### PR TITLE
Unit test for search endpoint

### DIFF
--- a/functions/tests/search_test.py
+++ b/functions/tests/search_test.py
@@ -35,5 +35,5 @@ def organization_full_table():
 
 
 @pytest.mark.parametrize('search_terms,expected_results', SEARCH_TEST_DATA)
-def test_search(organization_full_table, search_terms, expected_results):
-    assert search.search(search_terms)['results'] == expected_results
+def test_search(organization_full_table, terms, expected_results):
+    assert search.query(terms)['results'] == expected_results

--- a/functions/tests/search_test.py
+++ b/functions/tests/search_test.py
@@ -1,0 +1,39 @@
+import pytest
+
+from functions import OrganizationModel, organization, search
+
+
+ORGANIZATION_TEST_DATA = [{
+    'id': 'acme-inc',
+    'name': 'ACME, Inc.',
+    'description': 'Apparently, we make a ton of TNT.',
+}, {
+    'id': 'pals-forever-llc',
+    'name': 'Pals Forever, LLC',
+    'description': 'BFFs for life!',
+}, {
+    'id': 'better-life-for-cats',
+    'name': 'Better Life for Cats',
+    'description': 'BFFs for life!',
+}]
+
+SEARCH_TEST_DATA = (
+    ('acme', [ORGANIZATION_TEST_DATA[0]]),
+    ('tnt ton', [ORGANIZATION_TEST_DATA[0]]),
+    ('life', ORGANIZATION_TEST_DATA[1:]),
+)
+
+
+@pytest.fixture(scope='module')
+def organization_full_table():
+    if not OrganizationModel.exists():
+        OrganizationModel.create_table(read_capacity_units=1, write_capacity_units=1, wait=True)
+    for entry in ORGANIZATION_TEST_DATA:
+        organization.create(entry)
+    yield organization_full_table
+    OrganizationModel.delete_table()
+
+
+@pytest.mark.parametrize('search_terms,expected_results', SEARCH_TEST_DATA)
+def test_search(organization_full_table, search_terms, expected_results):
+    assert search.search(search_terms)['results'] == expected_results


### PR DESCRIPTION
The expectation here is that passing a search term like `tnt ton` will return an array of dictionaries like so:
```
[{
    'id': 'acme-inc',
    'name': 'ACME, Inc.',
    'description': 'Apparently, we make a ton of TNT.',
}]
```

Also assuming that name and description are the only fields being searched. The structure of the results can be changed as needed.